### PR TITLE
Add ability to copy email addresses

### DIFF
--- a/src/copyButtons.ts
+++ b/src/copyButtons.ts
@@ -33,6 +33,40 @@ export const setCopyButtons = (links: HTMLAnchorElement[]) => {
   });
 };
 
+export const setEmailCopyButtons = (links: HTMLAnchorElement[]) => {
+  links.forEach((link) => {
+    if (link.nextElementSibling?.classList.contains(`${PL.id}-button`)) return;
+
+    const href = link.getAttribute("href");
+
+    // check if there is a link
+    if (!href || !href.startsWith("mailto:")) return;
+
+    // extract email address without mailto: prefix
+    const email = href.replace(/^mailto:/, "");
+
+    // create button
+    const button = doc.createElement("button");
+    // add styles
+    button.classList.add(`${PL.id}-button`);
+    // add icon
+    button.innerHTML = clipboardIcon;
+
+    button.addEventListener("click", async () => {
+      try {
+        await parent.navigator.clipboard.writeText(email);
+        button.innerHTML = checkIcon;
+        setTimeout(() => (button.innerHTML = clipboardIcon), 1000);
+      } catch (e) {
+        console.error("Error while copying an email address", e);
+      }
+    });
+
+    // add button
+    link.insertAdjacentElement("afterend", button);
+  });
+};
+
 export const removeCopyButtons = () => {
   const buttons = [
     ...doc.querySelectorAll(`.${PL.id}-button`),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import "@logseq/libs";
 import { logseq as PL } from "../package.json";
-import { getExternalLinks } from "./utils";
+import { getEmailLinks, getExternalLinks } from "./utils";
 import { initLinksObserver, runLinksObserver } from "./observer";
-import { removeCopyButtons, setCopyButtons } from "./copyButtons";
+import { removeCopyButtons, setCopyButtons, setEmailCopyButtons } from "./copyButtons";
 
 export const clipboardIcon = `
 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
@@ -29,7 +29,9 @@ const main = () => {
     `,
   });
 
+  // Set copy buttons for external links and email links
   setCopyButtons(getExternalLinks());
+  setEmailCopyButtons(getEmailLinks());
 
   setTimeout(() => {
     initLinksObserver();

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -1,6 +1,6 @@
 import { doc } from "./global";
-import { setCopyButtons } from "./copyButtons";
-import { getExternalLinks } from "./utils";
+import { setCopyButtons, setEmailCopyButtons } from "./copyButtons";
+import { getEmailLinks, getExternalLinks } from "./utils";
 
 let linksObserver: MutationObserver;
 let linksObserverConfig: MutationObserverInit;
@@ -19,8 +19,14 @@ const linksObserverCallback: MutationCallback = function (mutationsList) {
     const addedNode = mutationItem.addedNodes[0] as HTMLElement;
     if (addedNode && addedNode.childNodes.length) {
       const extLinkList = getExternalLinks();
+      const emailLinkList = getEmailLinks();
+
       if (extLinkList.length) {
         setCopyButtons(extLinkList);
+      }
+
+      if (emailLinkList.length) {
+        setEmailCopyButtons(emailLinkList);
       }
     }
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,3 +5,9 @@ export const getExternalLinks = () => {
     ...doc.querySelectorAll(globals.extLinksSelector),
   ] as HTMLAnchorElement[];
 };
+
+export const getEmailLinks = () => {
+  // Query all links with mailto: href directly
+  const allLinks = [...doc.querySelectorAll('a[href^="mailto:"]')] as HTMLAnchorElement[];
+  return allLinks;
+};


### PR DESCRIPTION
Implements feature request from issue #2 to add copy buttons next to email addresses in Logseq, similar to the existing external link copy functionality.

Changes made:
- Added setEmailCopyButtons function to create copy buttons for mailto links
- Added getEmailLinks function using direct mailto: selector (a[href^="mailto:"]) to find email links regardless of CSS class
- Updated observer to handle both external links and email links separately
- Updated main initialization to set copy buttons for both link types
- Email copy buttons extract just the email address (removes mailto: prefix)

The email version uses a[href^="mailto:"] selector rather than using relying on .external-link class, as email links in Logseq do not have that class.

Fixes https://github.com/RubenSmn/logseq-copy-url/issues/2

This patch was generated with the help of claude code, with a bit of iteration and local testing to get it to generate something the right shape that works.

I've also done a bunch of developer experience improvements on `main` on my fork if you're interested, happy to PR those too, or you can just grab them. Let me know if you want any more PRs.

<img width="623" height="114" alt="image" src="https://github.com/user-attachments/assets/193f33b5-a4bf-404b-aeef-f185ad9db705" />
